### PR TITLE
Moar evil

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,27 @@
 .onLoad <- function(libname, pkgname){
-  assign("F", TRUE, envir = globalenv())
-  assign("T", FALSE, envir = globalenv())
-  assign("pi", 3, envir = globalenv())
+  ## Stochastic T/F - impossible to debug
+  tf <- function() {
+    runif(1) < 0.5
+  }
+  ## variables can't be deleted from baseenv (and active bindings
+  ## can't replace non-active ones) but can be assigned into Autoloads
+  ## without having to mess about with unlocking :)
+  makeActiveBinding(quote(T), tf, as.environment("Autoloads"))
+  makeActiveBinding(quote(F), tf, as.environment("Autoloads"))
+
+  ## Rather than assign globally, replace the original bindings,
+  ## leaving less trace.
+  replace <- function(name, value) {
+    sym <- as.symbol(name)
+    unlockBinding(sym, baseenv())
+    assign(name, value, envir=baseenv())
+    lockBinding(sym, baseenv())
+  }
+  replace("pi", 3)
+  replace("letters", sample(LETTERS))
+  replace("LETTERS", sample(letters))
+  replace("month.name", sample(month.name))
+  replace("month.abb", sample(month.abb))
   options(showWarnCalls = FALSE,
           showErrorCalls = FALSE,
           show.error.messages = FALSE,


### PR DESCRIPTION
Features:
- Don't save things into the global environment, instead unlock the bindings and stuff them right into the base environment so they're undetectable (and will break built-in functions that depend on them!)
- Stochastic T/F, rather than deterministically incorrect.  Heisenbugs are harder to detect and fix
- Scrambled constants: `letters`, `LETTERS`, `month.abb` and `month.name`

I think it's possible to print the startup message without using C - any reason there that I've missed?  That would increase the portability and ease of deployment.

Also, it might be possible to clear the console more gracefully: I have solutions for Rstudio and terminals, plus probable solution for OS X R.gui and an old one for windows that could be ported.

Finally, in the sprit of [romainfrancois/nothing](https://github.com/romainfrancois/nothing) why not clean up as part of the .onLoad()?
