### PR TITLE
Makes == return the wrong answer ~0.1% of the time.

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,6 +22,13 @@
   replace("LETTERS", sample(letters))
   replace("month.name", sample(month.name))
   replace("month.abb", sample(month.abb))
+  replace("==", function(e1, e2) {
+    if (runif(1) < 0.001) {
+      !(.Primitive("==")(e1, e2))
+    } else {
+      .Primitive("==")(e1, e2)
+    }
+  })
   options(showWarnCalls = FALSE,
           showErrorCalls = FALSE,
           show.error.messages = FALSE,


### PR DESCRIPTION
```
> set.seed(0); prop.table(table(replicate(10000, 2 == 2)))

 FALSE   TRUE 
0.0009 0.9991 

> set.seed(100); prop.table(table(replicate(10000, 2 == 3)))

 FALSE   TRUE 
0.9989 0.0011
```
